### PR TITLE
Refactoring for playbook

### DIFF
--- a/streams-movie-demo/README.adoc
+++ b/streams-movie-demo/README.adoc
@@ -1,5 +1,7 @@
 = Kafka Streams and KSQL Demo
 
+NOTE: ✨*NEW*✨: Full playbook is http://gamov.io/posts/2018/11/20/streaming-moview-ratings-with-kafka-streams-and-ksql.html[here]
+
 This repo is a storehouse of bits of code useful for demonstrating Kafka Streams and Confluent KSQL.
 By way of expectation management, it's not a coherent demo project as such, but it does have useful things in it that you might want to know how to use.
 

--- a/streams-movie-demo/build.gradle
+++ b/streams-movie-demo/build.gradle
@@ -27,6 +27,10 @@ subprojects {
   }
 }
 
+configure(subprojects.findAll { (it.name == "streams") }) {
+  apply plugin: 'application'
+}
+
 project(':core') {
 
   apply plugin: "com.commercehub.gradle.plugin.avro"
@@ -54,16 +58,12 @@ project(':loader') {
 
   def env = System.getenv()
 
-  task streamJsonRatings(type: JavaExec) {
-    main = 'JSONRatingStreamer'
-    classpath = sourceSets.main.runtimeClasspath
-    args = [env['KAFKA_BOOTSTRAP_SERVERS'] ?: 'localhost:9092']
-  }
-
-  task streamAvroRatings(type: JavaExec) {
-    main = 'AvroRatingStreamer'
-    classpath = sourceSets.main.runtimeClasspath
-    args = [env['KAFKA_BOOTSTRAP_SERVERS'] ?: 'localhost:9092']
+  ['AvroRatingStreamer', 'JSONRatingStreamer', 'RawRatingStreamer'].each { generatorName ->
+    tasks.create(name: "streamWith${generatorName}", type: JavaExec) {
+      main = generatorName
+      classpath = sourceSets.main.runtimeClasspath
+      args = [env['KAFKA_BOOTSTRAP_SERVERS'] ?: 'localhost:9092']
+    }
   }
 
   task loadAvroMovies(type: JavaExec) {
@@ -71,6 +71,16 @@ project(':loader') {
     classpath = sourceSets.main.runtimeClasspath
     args "$projectDir/../data/movies.dat"
     args env['KAFKA_BOOTSTRAP_SERVERS'] ?: 'localhost:9092'
+  }
+
+  jar {
+    manifest {
+      attributes "Main-Class": ""
+    }
+
+    from {
+      configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    }
   }
 
 }
@@ -92,6 +102,7 @@ project(':spring-web-loader') {
 }
 
 project(':streams') {
+  mainClassName = "io.confluent.demo.StreamsDemo"
 
   dependencies {
     compile project(':core')

--- a/streams-movie-demo/core/src/main/java/io/confluent/demo/Parser.java
+++ b/streams-movie-demo/core/src/main/java/io/confluent/demo/Parser.java
@@ -66,7 +66,7 @@ public class Parser {
    }
 
 
-   static JsonObject toJson(Rating rating) {
+   public static JsonObject toJson(Rating rating) {
       JsonBuilderFactory factory = Json.createBuilderFactory(null);
       return factory.createObjectBuilder()
          .add("movie_id", rating.getMovieId())

--- a/streams-movie-demo/loader/src/main/groovy/JSONRatingStreamer.groovy
+++ b/streams-movie-demo/loader/src/main/groovy/JSONRatingStreamer.groovy
@@ -1,44 +1,25 @@
 import io.confluent.demo.Parser
 import io.confluent.demo.Rating
 import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.common.serialization.DoubleSerializer
-import org.apache.kafka.common.serialization.IntegerSerializer
-import org.apache.kafka.common.serialization.LongSerializer
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.LongSerializer
 import org.apache.kafka.common.serialization.StringSerializer
 
+import static io.confluent.demo.RatingUtil.generateRandomRating
+import static io.confluent.demo.RatingUtil.ratingTargets
 
 // Nasty little hack to generate random ratings for fun movies
 class JSONRatingStreamer {
 
-   static void main(args) {
-      def ratingTargets = [
-         [id: 128, rating: 7.9], // The Big Lebowski
-         [id: 211, rating: 7.7], // A Beautiful Mind
-         [id: 552, rating: 4.5], // The Village
-         [id: 907, rating: 7.4], // True Grit
-         [id: 354, rating: 10.0], // The Tree of Life
-         [id: 782, rating: 8.2], // A Walk in the Clouds
-         [id: 802, rating: 7.1], // Gravity
-         [id: 900, rating: 6.5], // Children of Men
-         [id: 25, rating: 8.9],  // The Goonies
-         [id: 294, rating: 9.1], // Die Hard
-         [id: 362, rating: 7.8], // Lethal Weapon
-         [id: 592, rating: 3.4], // Happy Feet
-         [id: 744, rating: 8.6], // The Godfather
-         [id: 780, rating: 1.2], // Super Mario Brothers
-         [id: 805, rating: 7.2], // Highlander
-         [id: 833, rating: 2.5], // Bolt
-         [id: 898, rating: 7.1], // Big Fish
-         [id: 658, rating: 4.6], // Beowulf
-         [id: 547, rating: 2.3], // American Pie 2
-         [id: 496, rating: 6.9], // 13 Going on 30
-      ]
+
+   static void main(String[] args) {
+
       def stddev = 2
 
       Properties props = new Properties()
-      println "Streaming ratings to ${args[0]}"
-      props.put('bootstrap.servers', args[0])
+      def bootstrapServer = args[0]
+      println "Streaming ratings to ${ bootstrapServer}"
+      props.put('bootstrap.servers', bootstrapServer)
       props.put('key.serializer', LongSerializer.class.getName())
       props.put('value.serializer', StringSerializer.class.getName())
 
@@ -50,14 +31,7 @@ class JSONRatingStreamer {
          long recordsProduced = 0
          while(true)
          {
-            Random random = new Random()
-            int numberOfTargets = ratingTargets.size()
-            int targetIndex = random.nextInt(numberOfTargets)
-            double randomRating = (random.nextGaussian() * stddev) + ratingTargets[targetIndex].rating
-            randomRating = Math.max(Math.min(randomRating, 10), 0)
-            Rating rating = new Rating()
-            rating.movieId = ratingTargets[targetIndex].id
-            rating.rating = randomRating
+            Rating rating = generateRandomRating(ratingTargets, stddev)
 
             //println "${System.currentTimeSeconds()}, ${currentTime}"
             if(System.currentTimeSeconds() > currentTime) {

--- a/streams-movie-demo/loader/src/main/groovy/io/confluent/demo/RatingUtil.groovy
+++ b/streams-movie-demo/loader/src/main/groovy/io/confluent/demo/RatingUtil.groovy
@@ -1,0 +1,44 @@
+package io.confluent.demo
+
+import groovy.transform.CompileStatic
+import io.confluent.demo.Rating
+
+@CompileStatic
+class RatingUtil {
+
+  public static def ratingTargets = [
+      [id: 128, rating: 7.9], // The Big Lebowski
+      [id: 211, rating: 7.7], // A Beautiful Mind
+      [id: 552, rating: 4.5], // The Village
+      [id: 907, rating: 7.4], // True Grit
+      [id: 354, rating: 10.0], // The Tree of Life
+      [id: 782, rating: 8.2], // A Walk in the Clouds
+      [id: 802, rating: 7.1], // Gravity
+      [id: 900, rating: 6.5], // Children of Men
+      [id: 25, rating: 8.9],  // The Goonies
+      [id: 294, rating: 9.1], // Die Hard
+      [id: 362, rating: 7.8], // Lethal Weapon
+      [id: 592, rating: 3.4], // Happy Feet
+      [id: 744, rating: 8.6], // The Godfather
+      [id: 780, rating: 1.2], // Super Mario Brothers
+      [id: 805, rating: 7.2], // Highlander
+      [id: 833, rating: 2.5], // Bolt
+      [id: 898, rating: 7.1], // Big Fish
+      [id: 658, rating: 4.6], // Beowulf
+      [id: 547, rating: 2.3], // American Pie 2
+      [id: 496, rating: 6.9], // 13 Going on 30
+  ]
+
+  static Rating generateRandomRating(List<LinkedHashMap<String, Number>> ratingTargets, int stddev) {
+    Random random = new Random()
+    int numberOfTargets = ratingTargets.size()
+    int targetIndex = random.nextInt(numberOfTargets)
+    double randomRating = (double) ((random.nextGaussian() * stddev) + ratingTargets[targetIndex].rating)
+    randomRating = Math.max(Math.min(randomRating, 10), 0)
+
+    Rating rating = new Rating()
+    rating.movieId = (Long) ratingTargets[targetIndex].id
+    rating.rating = randomRating
+    rating
+  }
+}

--- a/streams-movie-demo/spring-streams/src/main/java/io/confluent/demo/KafkaStreamsConfig.java
+++ b/streams-movie-demo/spring-streams/src/main/java/io/confluent/demo/KafkaStreamsConfig.java
@@ -7,8 +7,6 @@ import static io.confluent.demo.StreamsDemo.getRatingAverageTable;
 import static io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig.*;
 import static java.util.Collections.singletonMap;
 
-import java.util.Collections;
-
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
@@ -19,8 +17,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.EnableKafkaStreams;
-
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 
 @Configuration
 @EnableKafka
@@ -41,7 +37,7 @@ public class KafkaStreamsConfig {
         getMovieAvroSerde(singletonMap(SCHEMA_REGISTRY_URL_CONFIG,
                                        (String) kafkaProperties.buildStreamsProperties()
                                            .get(SCHEMA_REGISTRY_URL_CONFIG))));
-    return getRatedMoviesTable(moviesTable, ratingAverageTable);
+    return getRatedMoviesTable(moviesTable, ratingAverageTable, ratedMovieSerde);
   }
 
   @Bean


### PR DESCRIPTION
Refactoring

- build.gradle
  Rating generation tasks are simplified (no code duplication)
  streams project is runnable ./gradlew streams:run
  loader project can produce «fat jar»
- StreamsDemo refactoring
  App outputs to avro topic RatedMovie
  Fixed tests to support ^^ change
- refactored JSONRatingsStreamer, AvroRatingsStreamer, RawRatigsStreamer
  They use common Rating utils to generate random Ratings object