### PR TITLE
Enable logbin by overriding my.cnf

### DIFF
--- a/ksql-workshop/docker-compose.yml
+++ b/ksql-workshop/docker-compose.yml
@@ -176,6 +176,7 @@ services:
      - MYSQL_PASSWORD=mysqlpw
     volumes:
      - ${PWD}/data/customers.sql:/docker-entrypoint-initdb.d/z99_dump.sql
+     - ./my.cnf:/etc/mysql/my.cnf
 
   connect-debezium:
     image: debezium/connect:0.9.2.Final

--- a/ksql-workshop/my.cnf
+++ b/ksql-workshop/my.cnf
@@ -1,0 +1,46 @@
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+skip-host-cache
+skip-name-resolve
+#datadir=/var/lib/mysql
+#socket=/var/lib/mysql/mysql.sock
+#secure-file-priv=/var/lib/mysql-files
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+#log-error=/var/log/mysqld.log
+#pid-file=/var/run/mysqld/mysqld.pid
+
+# ----------------------------------------------
+# Enable the binlog for replication & CDC
+# ----------------------------------------------
+
+# Enable binary replication log and set the prefix, expiration, and log format.
+# The prefix is arbitrary, expiration can be short for integration tests but would
+# be longer on a production system. Row-level info is required for ingest to work.
+# Server ID is required, but this will vary on production systems
+server-id         = 223344
+log-bin           = mysql-bin
+expire_logs_days  = 1
+binlog_format     = row
+
+


### PR DESCRIPTION
Hi, When I submitted my source connector using docker-compose exec connect-debezium bash -c '/scripts/create-mysql-source.sh' command, It was successful but, it's task failed. I saw this using connector REST API:

        {
            "name": "mysql-source-demo-customers",
            "connector": {
                "state": "RUNNING",
                "worker_id": "172.22.0.12:8083"
            },
            "tasks": [
                {
                    "id": 0,
                    "state": "FAILED",
                    "worker_id": "172.22.0.12:8083",
                    "trace": "org.apache.kafka.connect.errors.ConnectException: Cannot read the binlog filename and position via 'SHOW MASTER STATUS'. Make sure your server is correctly configured
            at io.debezium.connector.mysql.AbstractReader.wrap(AbstractReader.java: 230)
            at io.debezium.connector.mysql.AbstractReader.failed(AbstractReader.java: 208)
            at io.debezium.connector.mysql.SnapshotReader.execute(SnapshotReader.java: 678)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java: 1149)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java: 624)
            at java.lang.Thread.run(Thread.java: 748)
            Caused by: java.lang.IllegalStateException: Cannot read the binlog filename and position via 'SHOW MASTER STATUS'. Make sure your server is correctly configured
            at io.debezium.connector.mysql.SnapshotReader.lambda$readBinlogPosition$16(SnapshotReader.java: 710)
            at io.debezium.jdbc.JdbcConnection.query(JdbcConnection.java: 436)
            at io.debezium.jdbc.JdbcConnection.query(JdbcConnection.java: 377)
            at io.debezium.connector.mysql.SnapshotReader.readBinlogPosition(SnapshotReader.java: 694)
            at io.debezium.connector.mysql.SnapshotReader.execute(SnapshotReader.java: 252)
            ... 3 more
            "
                }
            ],
            "type": "source"
        }

Using [https://serverfault.com/questions/366924/mysql-check-enable-binary-logs](https://serverfault.com/questions/366924/mysql-check-enable-binary-logs) answer I found that my binlog is not enabled. It seems that binlog configuration is not enabled because its configuration has been overridden by another configuration. 

I overridden my.cnf file to prevent the problem. 