### PR TITLE
Fix for docker-compose pull error

### DIFF
--- a/ksql-workshop/docker-compose.yml
+++ b/ksql-workshop/docker-compose.yml
@@ -257,7 +257,6 @@ services:
       discovery.type: "single-node"
 
   websockets:
-    image: ksql-workshop-websockets
     container_name: websockets
     build: ./websockets
   


### PR DESCRIPTION
Fix for #84. Removing the `image` so `docker-compose pull` from the prerequisites doesn't break.