### PR TITLE
Clarifiy doc: schema_registry_basic_auth syntax

### DIFF
--- a/pacman-ccloud/README.adoc
+++ b/pacman-ccloud/README.adoc
@@ -57,7 +57,7 @@ cluster_api_key = "<CCLOUD_API_KEY>"
 cluster_api_secret = "<CCLOUD_API_SECRET>"
 
 schema_registry_url = "<SCHEMA_REGISTRY_URL>"
-schema_registry_basic_auth = "<SCHEMA_REGISTRY_BASIC_AUTH>"
+schema_registry_basic_auth = "<SCHEMA_REGISTRY_API_KEY>:<SCHEMA_REGISTRY_SECRET>"
 ----
 
 4. Create a variables file for AWS
@@ -131,7 +131,7 @@ cluster_api_key = "<CCLOUD_API_KEY>"
 cluster_api_secret = "<CCLOUD_API_SECRET>"
 
 schema_registry_url = "<SCHEMA_REGISTRY_URL>"
-schema_registry_basic_auth = "<SCHEMA_REGISTRY_BASIC_AUTH>"
+schema_registry_basic_auth = "<SCHEMA_REGISTRY_API_KEY>:<SCHEMA_REGISTRY_SECRET>"
 ----
 
 4. Create a variables file for GCP
@@ -219,7 +219,7 @@ cluster_api_key = "<CCLOUD_API_KEY>"
 cluster_api_secret = "<CCLOUD_API_SECRET>"
 
 schema_registry_url = "<SCHEMA_REGISTRY_URL>"
-schema_registry_basic_auth = "<SCHEMA_REGISTRY_BASIC_AUTH>"
+schema_registry_basic_auth = "<SCHEMA_REGISTRY_API_KEY>:<SCHEMA_REGISTRY_SECRET>"
 ----
 
 4. Create a variables file for Azure

--- a/pacman-ccloud/terraform/aws/ccloud.auto.tfvars.example
+++ b/pacman-ccloud/terraform/aws/ccloud.auto.tfvars.example
@@ -2,9 +2,9 @@
 ############# Confluent Cloud #############
 ###########################################
 
-bootstrap_server = "<CCLOUD_BOOTSTRA_SERVER>"
+bootstrap_server = "<CCLOUD_BOOTSTRAP_SERVER>"
 cluster_api_key = "<CCLOUD_API_KEY>"
 cluster_api_secret = "<CCLOUD_API_SECRET>"
 
 schema_registry_url = "<SCHEMA_REGISTRY_URL>"
-schema_registry_basic_auth = "<SCHEMA_REGISTRY_BASIC_AUTH>"
+schema_registry_basic_auth = "<SCHEMA_REGISTRY_API_KEY>:<SCHEMA_REGISTRY_SECRET>"

--- a/pacman-ccloud/terraform/azr/ccloud.auto.tfvars.example
+++ b/pacman-ccloud/terraform/azr/ccloud.auto.tfvars.example
@@ -2,9 +2,9 @@
 ############# Confluent Cloud #############
 ###########################################
 
-bootstrap_server = "<CCLOUD_BOOTSTRA_SERVER>"
+bootstrap_server = "<CCLOUD_BOOTSTRAP_SERVER>"
 cluster_api_key = "<CCLOUD_API_KEY>"
 cluster_api_secret = "<CCLOUD_API_SECRET>"
 
 schema_registry_url = "<SCHEMA_REGISTRY_URL>"
-schema_registry_basic_auth = "<SCHEMA_REGISTRY_BASIC_AUTH>"
+schema_registry_basic_auth = "<SCHEMA_REGISTRY_API_KEY>:<SCHEMA_REGISTRY_SECRET>"

--- a/pacman-ccloud/terraform/gcp/ccloud.auto.tfvars.example
+++ b/pacman-ccloud/terraform/gcp/ccloud.auto.tfvars.example
@@ -2,9 +2,9 @@
 ############# Confluent Cloud #############
 ###########################################
 
-bootstrap_server = "<CCLOUD_BOOTSTRA_SERVER>"
+bootstrap_server = "<CCLOUD_BOOTSTRAP_SERVER>"
 cluster_api_key = "<CCLOUD_API_KEY>"
 cluster_api_secret = "<CCLOUD_API_SECRET>"
 
 schema_registry_url = "<SCHEMA_REGISTRY_URL>"
-schema_registry_basic_auth = "<SCHEMA_REGISTRY_BASIC_AUTH>"
+schema_registry_basic_auth = "<SCHEMA_REGISTRY_API_KEY>:<SCHEMA_REGISTRY_SECRET>"


### PR DESCRIPTION
Update readme for Pacman ccloud demonstration : clarifying the syntax for schema registry setup