### PR TITLE
Gn pacman gcp fix

### DIFF
--- a/pacman-ccloud/terraform/gcp/compute.tf
+++ b/pacman-ccloud/terraform/gcp/compute.tf
@@ -161,5 +161,5 @@ resource "google_compute_instance_template" "ksql_server" {
     access_config {
     }
   }
-  tags = ["ksql-server-${var.global_prefix}"]
+  tags = ["${var.global_prefix}-ksql-server"]
 }

--- a/pacman-ccloud/terraform/gcp/main.tf
+++ b/pacman-ccloud/terraform/gcp/main.tf
@@ -34,6 +34,7 @@ resource "google_storage_bucket" "pacman" {
       main_page_suffix = "index.html"
       not_found_page = "error.html"
   }
+  force_destroy = "true"
 }
 
 resource "google_storage_default_object_acl" "default_obj_acl" {


### PR DESCRIPTION
This will fix a couple  of issues with the pacman demo for GCP .

- Tags mismatch between ksql VM and networking configuration in terraform
- missing force_destroy property in bucket creation (in terraform), would a new terraform apply after a terraform destroy would fail without manual deletion of the bucket on GCP console