### PR TITLE
Minor: Update ksqlDB WINDOWSTART syntax in build-a-streaming-pipeline

### DIFF
--- a/build-a-streaming-pipeline/demo_build-a-streaming-pipeline.adoc
+++ b/build-a-streaming-pipeline/demo_build-a-streaming-pipeline.adoc
@@ -517,7 +517,7 @@ Simple aggregation - count of ratings per person, per minute:
 
 [source,sql]
 ----
-SELECT TIMESTAMPTOSTRING(WindowStart(), 'yyyy-MM-dd HH:mm:ss') AS WINDOW_START_TS, 
+SELECT TIMESTAMPTOSTRING(WINDOWSTART, 'yyyy-MM-dd HH:mm:ss') AS WINDOW_START_TS,
        FULL_NAME,COUNT(*) AS RATINGS_COUNT
   FROM RATINGS_WITH_CUSTOMER_DATA 
         WINDOW TUMBLING (SIZE 1 MINUTE) 

--- a/build-a-streaming-pipeline/demo_build-a-streaming-pipeline.html
+++ b/build-a-streaming-pipeline/demo_build-a-streaming-pipeline.html
@@ -1090,7 +1090,7 @@ ratings-enriched               3699</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">SELECT TIMESTAMPTOSTRING(WindowStart(), 'yyyy-MM-dd HH:mm:ss') AS WINDOW_START_TS,
+<pre class="highlight"><code class="language-sql" data-lang="sql">SELECT TIMESTAMPTOSTRING(WINDOWSTART, 'yyyy-MM-dd HH:mm:ss') AS WINDOW_START_TS,
        FULL_NAME,COUNT(*) AS RATINGS_COUNT
   FROM RATINGS_WITH_CUSTOMER_DATA
         WINDOW TUMBLING (SIZE 1 MINUTE)


### PR DESCRIPTION
The latest ksqlDB versions (including 0.7.1, used by the build-a-streaming-pipeline demo) uses the `WINDOWSTART` syntax rather than the old `WindowStart()` (see https://github.com/confluentinc/ksql/pull/4459). Other parts of the build-a-streaming-pipeline demo were already updated to use this new syntax, but the update was missed for the particular command updated in this PR.