### PR TITLE
DOCS-5513 updates to demo-scene/cluster-linking README per Luke's review

### DIFF
--- a/cluster-linking/README.md
+++ b/cluster-linking/README.md
@@ -1,8 +1,12 @@
 # Cluster Linking Demo
 
-Cluster Linking allows two or more clusters to directly connect at the broker level. It eliminates the need to monitor, secure, and scale 
-another distributed system (e.g. Kafka Connect) to replicate data from one cluster to another--all while preserving offsets to help rationalize about the state of the system.
+Cluster Linking allows two or more clusters to directly connect at the broker
+level. It eliminates the need to monitor, secure, and scale  another distributed
+system (e.g. Kafka Connect) to replicate data from one cluster to another--all
+while preserving offsets to help rationalize about the state of the system.
 
-For information on how to run this demo, please reference the Confluent documentation [here](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/index.html).
+For information on how to run this demo, please reference the [Cluster Linking Demo (Docker)](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/docker-quickstart.html) in the Confluent documentation.
 
-Note: Cluster Linking is currently in preview in CP 6.0.
+The full documentation set includes: [Cluster Linking Preview (Overview)](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/index.html), [Demo (Docker)](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/docker-quickstart.html), [Tutorial (Local)](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/tutorial.html), [Commands Reference](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/commands.html), [Configuration Options](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/configs.html), [Metrics and Monitoring](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/metrics.html), and [Security](https://docs.confluent.io/current/multi-dc-deployments/cluster-linking/security.html).
+
+**Note:** Cluster Linking is currently in preview in CP 6.0.


### PR DESCRIPTION
Updates to Documentation links in the README per review comments from @lukeknep on https://confluentinc.atlassian.net/browse/DOCS-5513

For review: [Link to rendered README](https://github.com/confluentinc/demo-scene/blob/40f70086e7875cf9c5bc60094e40159e3f19ab19/cluster-linking/README.md)



Signed-off-by: Victoria Bialas <vicky@confluent.io>