### PR TITLE
Update broken link in README

### DIFF
--- a/kafka-connect-zero-to-hero/README.adoc
+++ b/kafka-connect-zero-to-hero/README.adoc
@@ -2,7 +2,7 @@
 
 == 👾 Demo code
 
-Follow the script link:/demo_zero-to-hero-with-kafka-connect.adoc[here]
+Follow the script link:/kafka-connect-zero-to-hero/demo_zero-to-hero-with-kafka-connect.adoc[here]
 
 == 📔 Slides
 


### PR DESCRIPTION
The link to the demo script was a dead link. Updated to the proper path.