### PR TITLE
Ibm demo - Fix to add connect-jars folder

### DIFF
--- a/ibm-demo/.gitignore
+++ b/ibm-demo/.gitignore
@@ -1,1 +1,3 @@
 mqlibs/*
+!connect-jars
+

--- a/ibm-demo/.gitignore
+++ b/ibm-demo/.gitignore
@@ -1,2 +1,1 @@
 mqlibs/*
-connect-jars/*

--- a/ibm-demo/connect-jars/README.md
+++ b/ibm-demo/connect-jars/README.md
@@ -1,0 +1,1 @@
+This folder will host jars, leave this files alone :)

--- a/ibm-demo/connect-jars/README.md
+++ b/ibm-demo/connect-jars/README.md
@@ -1,1 +1,1 @@
-This folder will host jars, leave this files alone :)
+This folder will host jars, leave these files alone :)


### PR DESCRIPTION
Sorry @rmoff , I didn't realize there was a gitignore exclusion for the connect-jars folder in the main gitignore.
I added an exclusion for my demo folder.
Thanks!