### PR TITLE
Streaming-pacman fix - Adding region to the terraform configs

### DIFF
--- a/streaming-pacman/start.sh
+++ b/streaming-pacman/start.sh
@@ -15,6 +15,9 @@ export TOPICS_TO_CREATE="USER_GAME USER_LOSSES"
 
 
 function create_tfvars_file {
+
+    AWS_REGION=$(echo "$BOOTSTRAP_SERVERS" | awk -F'.' '{print $2}')
+   
     TFVAR_S3_BUCKET=""
     if [ -z ${S3_BUCKET_NAME+x} ]; 
     then 
@@ -35,6 +38,7 @@ ksql_endpoint="$KSQLDB_ENDPOINT"
 ksql_basic_auth_user_info="$KSQLDB_BASIC_AUTH_USER_INFO"
 aws_access_key="$AWS_ACCESS_KEY"
 aws_secret_key="$AWS_SECRET_KEY"
+aws_region="$AWS_REGION"
 $TFVAR_S3_BUCKET
 
 EOF

--- a/streaming-pacman/terraform/aws/main.tf
+++ b/streaming-pacman/terraform/aws/main.tf
@@ -5,7 +5,8 @@
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
-  region = local.region
+  region     = var.aws_region
+
 }
 
 data "aws_availability_zones" "available" {
@@ -76,6 +77,10 @@ variable "aws_secret_key" {
   type = string
 }
 
+variable "aws_region" {
+  type = string
+}
+
 ###########################################
 ############ CCloud Variables #############
 ###########################################
@@ -90,10 +95,6 @@ variable "cluster_api_key" {
 
 variable "cluster_api_secret" {
   type = string
-}
-
-locals {
-  region = split(".", var.bootstrap_server)[1]
 }
 
 variable "scoreboard_topic" {


### PR DESCRIPTION
Using locals seems to cause issue at destroy time. I have moved the logic to extract the aws region from Confluent cluster bootstrap URL in the start.sh . This way it is showing up as an autogenerated variable in the configs.auto.tfvars