### PR TITLE
IBM Demo fix db2 port

### DIFF
--- a/ibm-demo/README.md
+++ b/ibm-demo/README.md
@@ -5,10 +5,14 @@
 This repository demonstrates how to integrate with IBM technologies (IBM MQ and DB2). Two connectors will be started up: Datagen source, to mock clickstream data and IBM MQ Connetor source. Then we'll use KSQL to join the two sources together. We'll also configure a IBM DB2 source connector to read data from DB2. The resut of the ksqlDB join will be sent to IBM MQ using a sink connector.
 
 ## Download the demo
-Clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
+Using your terminal, clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
 
 ```bash
 git clone https://github.com/confluentinc/demo-scene
+```
+Then enter the demo folder:
+
+```bash
 cd demo-scene/ibm-demo
 ```
 

--- a/ibm-demo/README.md
+++ b/ibm-demo/README.md
@@ -5,11 +5,18 @@
 This repository demonstrates how to integrate with IBM technologies (IBM MQ and DB2). Two connectors will be started up: Datagen source, to mock clickstream data and IBM MQ Connetor source. Then we'll use KSQL to join the two sources together. We'll also configure a IBM DB2 source connector to read data from DB2. The resut of the ksqlDB join will be sent to IBM MQ using a sink connector.
 
 ## Download the demo
-Using your terminal, clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
+Using your terminal, Download the zip containing this [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
 
 ```bash
-git clone https://github.com/confluentinc/demo-scene
-cd demo-scene/ibm-demo
+wget http://github.com/confluentinc/demo-scene/archive/master.zip
+```
+
+Then unzip the file and enter in the directory demo-scene-master/ibm-demo from your teminal.
+If you are using a Mac or similar commands should be:
+
+```bash
+unzip master.zip
+cd demo-scene-master/ibm-demo
 ```
 
 ## Make commands

--- a/ibm-demo/README.md
+++ b/ibm-demo/README.md
@@ -5,14 +5,10 @@
 This repository demonstrates how to integrate with IBM technologies (IBM MQ and DB2). Two connectors will be started up: Datagen source, to mock clickstream data and IBM MQ Connetor source. Then we'll use KSQL to join the two sources together. We'll also configure a IBM DB2 source connector to read data from DB2. The resut of the ksqlDB join will be sent to IBM MQ using a sink connector.
 
 ## Download the demo
-Using your terminal, clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
+Clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
 
 ```bash
 git clone https://github.com/confluentinc/demo-scene
-```
-Then enter the demo folder:
-
-```bash
 cd demo-scene/ibm-demo
 ```
 

--- a/ibm-demo/README.md
+++ b/ibm-demo/README.md
@@ -5,7 +5,7 @@
 This repository demonstrates how to integrate with IBM technologies (IBM MQ and DB2). Two connectors will be started up: Datagen source, to mock clickstream data and IBM MQ Connetor source. Then we'll use KSQL to join the two sources together. We'll also configure a IBM DB2 source connector to read data from DB2. The resut of the ksqlDB join will be sent to IBM MQ using a sink connector.
 
 ## Download the demo
-Using your terminal, lone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
+Using your terminal, clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
 
 ```bash
 git clone https://github.com/confluentinc/demo-scene

--- a/ibm-demo/README.md
+++ b/ibm-demo/README.md
@@ -5,7 +5,7 @@
 This repository demonstrates how to integrate with IBM technologies (IBM MQ and DB2). Two connectors will be started up: Datagen source, to mock clickstream data and IBM MQ Connetor source. Then we'll use KSQL to join the two sources together. We'll also configure a IBM DB2 source connector to read data from DB2. The resut of the ksqlDB join will be sent to IBM MQ using a sink connector.
 
 ## Download the demo
-Clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
+Using your terminal, lone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
 
 ```bash
 git clone https://github.com/confluentinc/demo-scene

--- a/ibm-demo/README.md
+++ b/ibm-demo/README.md
@@ -5,9 +5,12 @@
 This repository demonstrates how to integrate with IBM technologies (IBM MQ and DB2). Two connectors will be started up: Datagen source, to mock clickstream data and IBM MQ Connetor source. Then we'll use KSQL to join the two sources together. We'll also configure a IBM DB2 source connector to read data from DB2. The resut of the ksqlDB join will be sent to IBM MQ using a sink connector.
 
 ## Download the demo
-You can download the demo [here](https://bit.ly/3ex1tLx)
+Clone the [confluentinc/demo-scene](https://github.com/confluentinc/demo-scene) GitHub repository..
 
-Unzip the ibm-demo.zip and cd into the directory from your terminal.
+```bash
+git clone https://github.com/confluentinc/demo-scene
+cd demo-scene/ibm-demo
+```
 
 ## Make commands
 

--- a/ibm-demo/README.md
+++ b/ibm-demo/README.md
@@ -188,3 +188,14 @@ When you are done with the demo execute the command:
 ```conf
 make down
 ```
+
+## Troubleshooting tips
+
+```bash
+docker exec -ti ibmdb2 bash -c "su - db2inst1"
+db2 get dbm cfg | grep "SVCENAME"
+
+grep "db2c_db2inst1" /etc/services
+
+db2level
+```

--- a/ibm-demo/docker-compose.yml
+++ b/ibm-demo/docker-compose.yml
@@ -193,12 +193,12 @@ services:
       - .:/project
 
   ibmdb2:
-    image: ibmcom/db2
+    image: ibmcom/db2:11.5.6.0
     hostname: ibmdb2
     container_name: ibmdb2
     privileged: true
     ports:
-      - 50000:50000
+      - 25010:25010
     environment:
       LICENSE: accept
       DB2INST1_PASSWORD: passw0rd

--- a/ibm-demo/ibmmq/ibmdb2-source.json
+++ b/ibm-demo/ibmmq/ibmdb2-source.json
@@ -1,8 +1,7 @@
 {
 	"connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
 	"tasks.max":"1",
-	"mq.hostname": "ibmmq",
-	"connection.url":"jdbc:db2://ibmdb2:50000/sample",
+	"connection.url":"jdbc:db2://ibmdb2:25010/sample",
 	"connection.user":"db2inst1",
 	"connection.password":"passw0rd",
 	"topic.prefix": "db2-",


### PR DESCRIPTION
Hi there! Thanks to @jhogan-confluent  for the contribution! 
As of v11.5.6 IBM DB2 now uses 25000 range of ports. make connectdb2source was failing due to port mismatch. 
Some other changes:

- We are now enforcing the version of docker image for db2 , so we are sure the port will be the new default.
- I changed the instructions to download the zip file directly from git , so it will be easier to mantain. This will also make the download faster than cloning the whole repo (but slower than downloading an hand made zip with ibm-demo only)

Closes #224 , FYI @ora0600 