### PR TITLE
Fixed rabbitmq

### DIFF
--- a/rabbitmq-into-kafka/docker-compose.yml
+++ b/rabbitmq-into-kafka/docker-compose.yml
@@ -115,10 +115,8 @@ services:
   rabbitmq:
     image: rabbitmq:3-management
     container_name: rabbitmq
-    environment:
-      RABBITMQ_DEFAULT_USER: guest
-      RABBITMQ_DEFAULT_PASS: guest
-      RABBITMQ_DEFAULT_VHOST: "/"
+    volumes:
+      - "./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf"
     ports:
       - '15672:15672'
       - '5672:5672'

--- a/rabbitmq-into-kafka/rabbitmq.conf
+++ b/rabbitmq-into-kafka/rabbitmq.conf
@@ -1,0 +1,3 @@
+default_vhost = /
+default_user = guest
+default_pass = guest 


### PR DESCRIPTION
Rabbitmq deprecates environment variables after 3.9, causing the rabbitmq container to exit on start. 

I moved the environment variables to a config file and mounted it as a volume in docker-compose.yml to resolve the issue.