### PR TITLE
Update CLI commands - from ccloud to confluent CLI.

### DIFF
--- a/streaming-pacman/README.adoc
+++ b/streaming-pacman/README.adoc
@@ -27,7 +27,7 @@ The whole demo creation is scripted. The script will perform 2 main actions:
 +
 [source,bash]
 ----
-ccloud login --save
+confluent login --save
 ----
 
 The --save flag will save your Confluent Cloud login credentials to the ~/.netrc file.

--- a/streaming-pacman/create_ksqldb_app.sh
+++ b/streaming-pacman/create_ksqldb_app.sh
@@ -31,19 +31,19 @@ ccloud::validate_ksqldb_up "$KSQLDB_ENDPOINT" || exit 1
 for TOPIC in $TOPICS_TO_CREATE
 do
   echo -e "\n# Create new Kafka topic $TOPIC"
-  ccloud kafka topic create "$TOPIC"   
+  confluent kafka topic create "$TOPIC"
 done
 
-ccloud ksql app list
+confluent ksql cluster list
 
-ksqlDBAppId=$(ccloud ksql app list | grep "$KSQLDB_ENDPOINT" | awk '{print $1}')
+ksqlDBAppId=$(confluent ksql cluster list | grep "$KSQLDB_ENDPOINT" | awk '{print $1}')
 echo "ksqldb app id: ksqlDBAppId"
-ccloud ksql app configure-acls $ksqlDBAppId $TOPICS_TO_CREATE
+confluent ksql cluster configure-acls $ksqlDBAppId $TOPICS_TO_CREATE
 
-SERVICE_ACCOUNT_ID=$(ccloud kafka cluster list -o json | jq -r '.[0].name' | awk -F'-' '{print $4;}')
+SERVICE_ACCOUNT_ID=$(confluent kafka cluster describe -o json | jq -r '.name' | awk -F'-' '{print $4 "-" $5;}')
 for TOPIC in $TOPICS_TO_CREATE
 do
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $TOPIC      
+  confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $TOPIC
 done
 
 # Submit KSQL queries

--- a/streaming-pacman/start.sh
+++ b/streaming-pacman/start.sh
@@ -69,12 +69,12 @@ function create_ccloud_resources {
         return
     fi
 
-    ccloud::validate_version_ccloud_cli 1.7.0 \
-        && print_pass "ccloud version ok" \
+    ccloud::validate_version_cli 1.7.0 \
+        && print_pass "confluent CLI version ok" \
         || exit 1
 
-    ccloud::validate_logged_in_ccloud_cli \
-        && print_pass "logged into ccloud CLI" \
+    ccloud::validate_logged_in_cli \
+        && print_pass "logged into confluent CLI" \
         || exit 1
 
     check_jq \
@@ -85,7 +85,7 @@ function create_ccloud_resources {
     echo ====== Create new Confluent Cloud stack
     ccloud::prompt_continue_ccloud_demo || exit 1
     ccloud::create_ccloud_stack true
-    SERVICE_ACCOUNT_ID=$(ccloud kafka cluster list -o json | jq -r '.[0].name' | awk -F'-' '{print $4;}')
+    SERVICE_ACCOUNT_ID=$(confluent kafka cluster describe -o json | jq -r '.name' | awk -F'-' '{print $4 "-" $5;}')
     if [[ "$SERVICE_ACCOUNT_ID" == "" ]]; then
     echo "ERROR: Could not determine SERVICE_ACCOUNT_ID from 'ccloud kafka cluster list'. Please troubleshoot, destroy stack, and try again to create the stack."
     exit 1

--- a/streaming-pacman/utils/demo_helper.sh
+++ b/streaming-pacman/utils/demo_helper.sh
@@ -25,9 +25,9 @@ function ccloud::create_acls_fm_connectors_wildcard() {
     SERVICE_ACCOUNT_ID=$1
     CLUSTER=$2
 
-    ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation idempotent-write --cluster-scope --cluster $CLUSTER
-    ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation describe --cluster-scope --cluster $CLUSTER
-    ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation create --cluster-scope --cluster $CLUSTER
+    confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation idempotent-write --cluster-scope --cluster $CLUSTER
+    confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation describe --cluster-scope --cluster $CLUSTER
+    confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation create --cluster-scope --cluster $CLUSTER
 
     return 0
 }
@@ -40,8 +40,8 @@ function ccloud::create_topics(){
   for TOPIC in $TOPICS_TO_CREATE
   do
         echo -e "\n# Create new Kafka topic $TOPIC"
-        echo "ccloud kafka topic create \"$TOPIC\" --partitions $PARTITIONS"
-        ccloud kafka topic create "$TOPIC" --cluster $CLUSTER --partitions $PARTITIONS || true
+        echo "confluent kafka topic create \"$TOPIC\" --partitions $PARTITIONS"
+        confluent kafka topic create "$TOPIC" --cluster $CLUSTER --partitions $PARTITIONS || true
         # In some cases I received an error 500 but the topic is created successfully anyway...
   done
 }
@@ -49,7 +49,7 @@ function ccloud::create_topics(){
 ccloud::wait_for_data_in_topic() {
     local count=0
     while [[ "$count" -le 100 ]];do 
-        count=$(timeout 10 ccloud kafka topic consume -b $2 --cluster $1 | wc -l);
+        count=$(timeout 10 confluent kafka topic consume -b $2 --cluster $1 | wc -l);
         echo "At least $count messages in the topic"
         #timeout 3 ccloud kafka topic consume -b $2 --cluster $1
         sleep 0.1 


### PR DESCRIPTION
Streaming Pacman - Updated scripts to reflect recent changes on the environment; from ccloud to confluent CLI.

Updating all places referring to ccloud, replaced them with confluent, along with additional changes required to run it as indicated in the README instruction. Verified by running start.sh and playing Pacman.